### PR TITLE
U/ckometter/buffer ramp

### DIFF
--- a/include/ad4115.h
+++ b/include/ad4115.h
@@ -60,7 +60,7 @@ public:
 	uint8_t updateChannelStates(void);
 	//Iterates through array and counts the 1s--returns integer
 	double fullReading(void);
-	double bufferRampFullReading(void);
+	double bufferRampFullReading(uint8_t channelsAdc[16]);
 	uint8_t resetAdc(void);
 
 	//Test functions

--- a/include/ad4115.h
+++ b/include/ad4115.h
@@ -20,6 +20,7 @@ private:
 	//Functions
 	uint32_t twoByteToInt(byte db1, byte db2);
 	double threeByteToInt(uint8_t db1, uint8_t db2, uint8_t db3);
+	void intToThreeByte(uint32_t decimal);
 	double voltageMap(double decimal);
 	void waitDrdy(void);
 	

--- a/include/ramp.h
+++ b/include/ramp.h
@@ -26,9 +26,9 @@ private:
 public:
 	uint8_t rampCmd[20];
 	uint8_t simpleRamp(uint8_t channelsDAC[4], double vi[4], double vf[4], double nSteps, double del);
-	uint8_t bufferRamp(uint8_t channelsDAC[4], double vi[4], double vf[4], uint32_t nSteps, uint32_t del, uint8_t channelsADC[16]);
+	uint8_t bufferRamp(uint8_t channelsDAC[4], double vi[4], double vf[4], uint32_t nPoints, uint32_t del, uint8_t channelsADC[16]);
 	uint8_t simpleRampIteration(uint8_t channelsDAC[4], double vi[4], double nSteps, double del);
-	uint8_t bufferRampIteration(uint8_t channelsDAC[4], double vi[4], uint32_t nSteps, uint32_t del, uint8_t channelsADC[16]);
+	uint8_t bufferRampIteration(uint8_t channelsDAC[4], double vi[4], uint32_t nPoints, uint32_t del, uint8_t channelsADC[16]);
 
 	// Constructor
   	RAMPS(AD5791& dac, AD4115& adc);

--- a/include/ramp.h
+++ b/include/ramp.h
@@ -25,13 +25,13 @@ private:
 
 public:
 	uint8_t rampCmd[20];
-	uint8_t simpleRamp(uint8_t channelsDAC[4], double vi[4], double vf[4], double nSteps, double del, bool buffer);
+	uint8_t simpleRamp(uint8_t channelsDAC[4], double vi[4], double vf[4], double nSteps, double del);
+	uint8_t bufferRamp(uint8_t channelsDAC[4], double vi[4], double vf[4], uint32_t nSteps, uint32_t del, uint8_t channelsADC[16]);
 	uint8_t simpleRampIteration(uint8_t channelsDAC[4], double vi[4], double nSteps, double del);
-	uint8_t bufferRampIteration(uint8_t channelsDAC[4], double vi[4], double nSteps, double del);
+	uint8_t bufferRampIteration(uint8_t channelsDAC[4], double vi[4], uint32_t nSteps, uint32_t del, uint8_t channelsADC[16]);
 
 	// Constructor
   	RAMPS(AD5791& dac, AD4115& adc);
-
 };
 
 

--- a/include/ramp.h
+++ b/include/ramp.h
@@ -25,7 +25,6 @@ private:
 
 public:
 	uint8_t rampCmd[20];
-	uint8_t buffer(void);
 	uint8_t simpleRamp(uint8_t channelsDAC[4], double vi[4], double vf[4], double nSteps, double del, bool buffer);
 	uint8_t simpleRampIteration(uint8_t channelsDAC[4], double vi[4], double nSteps, double del);
 	uint8_t bufferRampIteration(uint8_t channelsDAC[4], double vi[4], double nSteps, double del);

--- a/include/utils.h
+++ b/include/utils.h
@@ -55,6 +55,12 @@ namespace spi_utils
         /// a sync_pin_ to HIGH. (blockSize*nBlocks <= kDataLen)
         ///
         uint8_t nBlocks;
+
+        void errorMessage(){
+            for (size_t i = 0; i < kDataLen; i++) {
+                msg[i] = 0xFF;
+            }    
+        }
       };
 
     //   uint8_t data_transfer(uint8_t data[], uint8_t blockSize, uint8_t nBlocks, uint8_t sync_pin) {

--- a/od-dacadc.ino
+++ b/od-dacadc.ino
@@ -125,7 +125,7 @@ uint8_t Router(String cmd[], uint8_t cmdSize) {
 
   else if (command == "ADC_CONFIG") {
     uint8_t data = adc.generalConfig(cmd[1].toInt(), cmd[2].toInt(), cmd[3].toInt(), cmd[4].toInt(), cmd[5].toInt());
-    Serial.println(data);
+    //Serial.println(data);
   }
 
   else if (command == "SETUP_CONFIG") {
@@ -134,7 +134,7 @@ uint8_t Router(String cmd[], uint8_t cmdSize) {
 
   else if (command == "DISABLE_ALL_CHANNELS") {
     uint8_t data = adc.disableAllChannels();
-    Serial.println(data);
+    //Serial.println(data);
   }
 
   //RAMP FUNCTIONS SECTION

--- a/od-dacadc.ino
+++ b/od-dacadc.ino
@@ -191,7 +191,7 @@ uint8_t Router(String cmd[], uint8_t cmdSize) {
     }
     
     //inputs: RAMP, ch1, ch2, ch3, ch4, vi1, vi2, vi3, vi4, vf1, vf2, vf3, vf4, nsteps, delay, buffer
-    ramp_fs.simpleRamp(channelsDac, vi, vf, cmd[13].toInt(), std::atof(cmd[14].c_str()), false);
+    ramp_fs.simpleRamp(channelsDac, vi, vf, cmd[13].toInt(), std::atof(cmd[14].c_str()));
   }
 
   else if (command == "BUFFER_RAMP") {
@@ -201,23 +201,49 @@ uint8_t Router(String cmd[], uint8_t cmdSize) {
     double vi[4] = {0, 0, 0, 0};
     double vf[4] = {0, 0, 0, 0};
 
+    uint8_t nChannelsDac = cmd[1].toInt();
+
+    uint32_t iterator = 2;
     //Create channelsDAC array of size [4]
-    for (int i = 1; i < 5; i++){
-      channelsDac[i - 1] = cmd[i].toInt();  
+    for (uint32_t i = iterator; i < iterator+nChannelsDac; i++) {
+      channelsDac[cmd[i].toInt()] = 1;  
     }
 
+    iterator += nChannelsDac;
+
     //Create vi array of size [4]
-    for (int i = 5; i < 9; i++){
-      vi[i - 5] = std::atof(cmd[i].c_str());  
+    for (uint32_t i = 0; i < 4; i++) {
+      if (channelsDac[i]) {
+        vi[i] = cmd[iterator].toFloat();
+        iterator++;
+      }
     }
 
     //Create vf array of size [4]
-    for (int i = 9; i < 13; i++){
-      vf[i - 9] = std::atof(cmd[i].c_str());  
+    for (uint32_t i = 0; i < 4; i++) {
+      if (channelsDac[i]) {
+        vf[i] = cmd[iterator].toFloat();
+        iterator++;
+      }
+    }
+
+    uint32_t nSteps = cmd[iterator].toInt();
+    iterator++;
+
+    uint32_t delay = cmd[iterator].toInt();
+    iterator++;
+
+    uint32_t nChannelsAdc = cmd[iterator].toInt();
+    iterator++;
+
+    //Create channelsAdc array of size [16]
+    uint8_t channelsAdc[16] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    for (uint32_t i = iterator; i < iterator+nChannelsAdc; i++) {
+      channelsAdc[cmd[i].toInt()] = 1;  
     }
 
     //inputs: RAMP, ch1, ch2, ch3, ch4, vi1, vi2, vi3, vi4, vf1, vf2, vf3, vf4, nsteps, delay, buffer
-    ramp_fs.simpleRamp(channelsDac, vi, vf, cmd[13].toInt(), std::atof(cmd[14].c_str()), true);
+    ramp_fs.bufferRamp(channelsDac, vi, vf, nSteps, delay, channelsAdc);
   }
 
   else if (command == "CONFIG_CHANNELS_TEST"){

--- a/od-dacadc.ino
+++ b/od-dacadc.ino
@@ -227,7 +227,7 @@ uint8_t Router(String cmd[], uint8_t cmdSize) {
       }
     }
 
-    uint32_t nSteps = cmd[iterator].toInt();
+    uint32_t nPoints = cmd[iterator].toInt();
     iterator++;
 
     uint32_t delay = cmd[iterator].toInt();
@@ -243,7 +243,7 @@ uint8_t Router(String cmd[], uint8_t cmdSize) {
     }
 
     //inputs: RAMP, ch1, ch2, ch3, ch4, vi1, vi2, vi3, vi4, vf1, vf2, vf3, vf4, nsteps, delay, buffer
-    ramp_fs.bufferRamp(channelsDac, vi, vf, nSteps, delay, channelsAdc);
+    ramp_fs.bufferRamp(channelsDac, vi, vf, nPoints, delay, channelsAdc);
   }
 
   else if (command == "CONFIG_CHANNELS_TEST"){

--- a/src/ad4115.cpp
+++ b/src/ad4115.cpp
@@ -751,8 +751,8 @@ double AD4115::fullReading(void) {
  *   3. Converts the read data to a decimal value using the `threeByteToInt()` function and stores it in the `_channelDecimals` array.
  *   4. Maps the decimal value to voltage using the `voltageMap()` function and stores it in the `_channelVoltages` array.
  * After processing all active channels, the function sets the `_adcSync` pin to HIGH. Finally, it iterates through all active
- * channels again and prints the channel number and corresponding voltage to the serial monitor using the `Serial.write()`
- * function. The function returns 0 indicating successful execution.
+ * channels again and prints the corresponding voltages in binary format to using the `Serial.write()` function.
+ * The function returns 0 indicating successful execution.
  *
  * @return 0 indicating successful execution.
  */
@@ -773,6 +773,7 @@ double AD4115::bufferRampFullReading(void) {
 
 	for (int i = 0; i < 16; i++) {
 		if (_channelStates[i] == 1) {
+			intToThreeByte(_channelDecimals[i]);
 			Serial.write(_dataRead[0]);
 			Serial.write(_dataRead[1]);
 			Serial.write(_dataRead[2]);

--- a/src/ad4115.cpp
+++ b/src/ad4115.cpp
@@ -620,6 +620,25 @@ double AD4115::threeByteToInt(uint8_t db1, uint8_t db2, uint8_t db3) {
 }
 
 /**
+ * @brief Divides an integer number into three bytes.
+ *
+ * This function divides an integer number into three bytes (db1, db2, db3) by performing bitwise operations.
+ * The resulting bytes d1, db2 and db3 are assigned to _dataRead[0], _dataRead[1] and _dataRead[2], respectively.
+ *
+ * @param decimal The integer to be divided.
+ * @return None.
+ */
+void AD4115::intToThreeByte(uint32_t decimal) {
+	uint8_t db1 = decimal >> 16;
+	uint8_t db2 = (decimal >> 8) - (db1 << 8);
+	uint8_t db3 = decimal - ((db2 << 8) + (db1 << 8));
+
+	_dataRead[0] = db1;
+	_dataRead[1] = db2;
+	_dataRead[2] = db3;
+}
+
+/**
  * @brief Generates a data reading message for the AD4115 ADC.
  *
  * This function generates a data reading message for the AD4115 ADC. The message is used to request data from the ADC.

--- a/src/ad4115.cpp
+++ b/src/ad4115.cpp
@@ -771,7 +771,7 @@ double AD4115::fullReading(void) {
  *
  * @return 0 indicating successful execution.
  */
-double AD4115::bufferRampFullReading(void) {
+double AD4115::bufferRampFullReading(uint8_t channelsAdc[16]) {
 	adcMode();
 
 	for (int i = 0; i < 16; i++) {
@@ -787,7 +787,7 @@ double AD4115::bufferRampFullReading(void) {
 	digitalWrite(_adcSync, HIGH);
 
 	for (int i = 0; i < 16; i++) {
-		if (_channelStates[i] == 1) {
+		if (channelsAdc[i] == 1) {
 			intToThreeByte(_channelDecimals[i]);
 			Serial.write(_dataRead[0]);
 			Serial.write(_dataRead[1]);

--- a/src/ad4115.cpp
+++ b/src/ad4115.cpp
@@ -765,10 +765,11 @@ double AD4115::fullReading(void) {
  *   2. Reads the data from the ADC using the `dataReading()` function.
  *   3. Converts the read data to a decimal value using the `threeByteToInt()` function and stores it in the `_channelDecimals` array.
  *   4. Maps the decimal value to voltage using the `voltageMap()` function and stores it in the `_channelVoltages` array.
- * After processing all active channels, the function sets the `_adcSync` pin to HIGH. Finally, it iterates through all active
- * channels again and prints the corresponding voltages in binary format to using the `Serial.write()` function.
+ * After processing all active `channelsAdc` channels, the function sets the `_adcSync` pin to HIGH. Finally, it iterates through all
+ * active `channelsAdc` channels again and prints the corresponding voltages in binary format to using the `Serial.write()` function.
  * The function returns 0 indicating successful execution.
- *
+ * 
+ * @param channelsAdc An array[16] indicating which channels to Serial.write().
  * @return 0 indicating successful execution.
  */
 double AD4115::bufferRampFullReading(uint8_t channelsAdc[16]) {

--- a/src/ad4115.cpp
+++ b/src/ad4115.cpp
@@ -183,22 +183,33 @@ spi_utils::Message AD4115::configChannelMsg(uint8_t channel, uint8_t state, uint
 					}
 					else {
 						Serial.println("INPUT 2 OUT OF RANGE");
+						msg.errorMessage();
+						return msg;
 					}
 				}
 				else {
 					Serial.println("INPUT 1 OUT OF RANGE");
+					msg.errorMessage();
+					return msg;
 				}
 			}
 			else {
 				Serial.println("INVALID INPUTS PAIR");
+				msg.errorMessage();
+				Serial.println(msg.msg[0]);
+				return msg;
 			}
 		}
 		else {
 			Serial.println("INVALID SETUP");
+			msg.errorMessage();
+			return msg;
 		}
 	}
 	else {
 		Serial.println("INVALID STATE");
+		msg.errorMessage();
+		return msg;
 	}
 
 	uint16_t channel_setup_mask = 0xFF00;
@@ -235,6 +246,9 @@ spi_utils::Message AD4115::configChannelMsg(uint8_t channel, uint8_t state, uint
 uint8_t AD4115::configChannel(uint8_t channel, uint8_t state,  uint8_t setup, uint8_t input_1, uint8_t input_2) {
 
 	spi_utils::Message msg = configChannelMsg(channel, state, setup, input_1, input_2);
+	if (msg.msg[0]==0xFF){
+		return 1;
+	}
 
 	SPI.beginTransaction(adcSettings);
 

--- a/src/ad4115.cpp
+++ b/src/ad4115.cpp
@@ -317,21 +317,21 @@ spi_utils::Message AD4115::setupConfigMsg(void) {
 
 	spi_utils::Message msg;
     
+	// 0 -- WEN [7]
+	// 0 -- WRITE [6]
     // 100000 -- Address [0:5] (e.g. Setup 0)
-    // 0 -- WRITE [6]
-    // 0 -- WEN [7]
     msg.msg[0] = 0x20; // Send 0010 0000 == 32
 
+	// Reserved [13:15] -- 000
+	// Bipolar/unipolar output coding [12] -- 1 (e.g. bipolar)
+	// Enable/disable REF(+) input buffer [11] -- 1 (e.g. enabled)
+	// Enable/disable REF(-) input buffer [10] -- 1 (e.g. enabled)
     // Enable/disable input buffers [8:9] -- 11 (e.g. enabled)
-    // Enable/disable REF(-) input buffer [10] -- 0 (e.g. disabled)
-    // Enable/disable REF(+) input buffer [11] -- 0 (e.g. disabled)
-    // Bipolar/unipolar output coding [12] -- 1 (e.g. bipolar)
-    // Reserved [13:15] -- 000
-    msg.msg[1] = 0x13; // Send 0001 0011 = 19
+    msg.msg[1] = 0x1F; // Send 0001 1111 = 31
     
+	// Reserved [6:7] -- 00
+	// Select ref source [4:5] -- 00 (e.g. external ref)
     // Reserved [0:3] -- 0000
-    // Select ref source [4:5] -- 00 (e.g. external ref)
-    // Reserved [6:7] -- 00
     msg.msg[2] = 0x00; // Send 0000 0000 = 0
 
     return msg;
@@ -382,25 +382,25 @@ spi_utils::Message AD4115::interfaceModeMsg(void) {
 
 	spi_utils::Message msg;
 
+	// 0 -- WEN [7]
+	// 0 -- WRITE [6]
     // 000010 -- Address [0:5]
-    // 0 -- WRITE [6]
-    // 0 -- WEN [7]
     msg.msg[0] = 0x02; // Send 0000 0010
 
+	// Reserved [13:15] -- 000
+	// ALT_SYNC [12] -- 0 (e.g. disabled)
+	// Drive strength of DOUT/DRY pin [11] -- 0 (e.g. disabled)
+	// Reserved [9:10] -- 00
     // DOUT_RESET [8] -- 0 (e.g. disabled)
-    // Reserved [9:10] -- 00
-    // Drive strength of DOUT/DRY pin [11] -- 0 (e.g. disabled)
-    // ALT_SYNC [12] -- 0 (e.g. disabled)
-    // Reserved [13:15] -- 000
     msg.msg[1] = 0x00; // Send 0000 0000
 
+	// Enables continue read mode [7] -- 0 (e.g. disabled)
+	// DATA_STAT [6] -- 0 (e.g. disabled)
+	// Register intgrity checker [5] -- 0 (e.g. disabled)
+	// Reserved [4] -- 0
+	// CRC protection [2:3] -- 00 (e.g. disabled)
+	// Reserved [1] -- 0
     // Change ADC to 16 bits [0] -- 0 (e.g. 24 bits)
-    // Reserved [1] -- 0
-    // CRC protection [2:3] -- 00 (e.g. disabled)
-    // Reserved [4] -- 0
-    // Register intgrity checker [5] -- 0 (e.g. disabled)
-    // DATA_STAT [6] -- 0 (e.g. disabled)
-    // Enables continue read mode [7] -- 0 (e.g. disabled)
     msg.msg[2] = 0x00; // Send 0000 0000
 
     return msg;
@@ -481,22 +481,22 @@ spi_utils::Message AD4115::adcModeMsg() {
 	
 	spi_utils::Message msg;
 
-    // 000001 -- Address [0:5]
-    // 0 -- WRITE [6]
-    // 0 -- WEN [7]
+	// 000001 -- Address [0:5]
+	// 0 -- WRITE [6]
+	// 0 -- WEN [7]
     msg.msg[0] = 0x01; // Send 0000 0001 
 
+	// REF_EN [15] -- 0 (e.g. disabled)
+	// Reserved [14] -- 0
+	// ON if single channel active [13] -- 0 (e.g. disabled)
+	// Reserved [11:12] -- 00
     // Delay [8:10] -- 000 (e.g. 0 microsecs)
-    // Reserved [11:12] -- 00
-    // ON if single channel active [13] -- 0 (e.g. disabled)
-    // Reserved [14] -- 0
-    // REF_EN [15] -- 0 (e.g. disabled)
     msg.msg[1] = 0x00; // Send 0000 0000
 
+	// Reserved [7] -- 0
+	// Operating mode [4:6] -- 001 (e.g. single conversion mode)
+	// ADC clock source [2:3] -- 11 kk
     // Reserved [0:1] -- 00
-    // ADC clock source [2:3] -- 11 kk
-    // Operating mode [4:6] -- 001 (e.g. single conversion mode)
-    // Reserved [7] -- 0
     msg.msg[2] = 0x1C; // Send 0001 1100
 
     return msg;
@@ -531,7 +531,7 @@ void AD4115::adcMode(void) {
             SPI.transfer(msg.msg[block * msg.blockSize + db]);
         }
 
-        digitalWrite(_adcSync, LOW);
+        //digitalWrite(_adcSync, LOW);
     }
     SPI.endTransaction();
 }
@@ -590,9 +590,10 @@ uint8_t AD4115::updateChannelStates(void) {
 /**
  * @brief Maps the decimal value to voltage.
  *
- * This function maps a decimal value to voltage using a specific formula. It takes a decimal value as input,
- * divides it by 8388607 (2^23 - 1), subtracts 1, and multiplies the result by 25. The resulting value represents
- * the voltage mapped from the decimal input. The function returns the mapped voltage as a double precision value.
+ * Only mapping to bipolar code is implemented. This function maps a decimal value to voltage using a specific formula.
+ * It takes a decimal value as input, divides it by 8388608 (2^23), subtracts 1, and multiplies the result by 25.
+ * The resulting value represents the voltage mapped from the decimal input. The function returns the mapped voltage
+ * as a double precision value.
  *
  * @param decimal The decimal value to be mapped to voltage.
  * @return The mapped voltage as a double precision value.

--- a/src/ramp.cpp
+++ b/src/ramp.cpp
@@ -131,7 +131,7 @@ uint8_t RAMPS::simpleRampIteration(uint8_t channelsDac[4], double vi[4], double 
  * @param del The delay in milliseconds between each step of the ramp.
  * @return void
  */
-uint8_t RAMPS::bufferRampIteration(uint8_t channelsDac[4], double vi[4], uint32_t nSteps, uint32_t del, uint8_t channelsAdc[16]) {
+uint8_t RAMPS::bufferRampIteration(uint8_t channelsDac[4], double vi[4], uint32_t nPoints, uint32_t del, uint8_t channelsAdc[16]) {
 
   double dv_j;
 
@@ -141,7 +141,11 @@ uint8_t RAMPS::bufferRampIteration(uint8_t channelsDac[4], double vi[4], uint32_
   //Initial reading before first step
   adc.bufferRampFullReading(channelsAdc);
 
-  for (int i = 0; i < nSteps; i++) {
+  if (nPoints==1){
+    return 0;
+  }
+
+  for (int i = 0; i < nPoints; i++) {
     for (int j = 0; j < 4; j++) {
       if (channelsDac[j] == 1) {
         dv_j = dv[j];
@@ -216,31 +220,13 @@ uint8_t RAMPS::simpleRamp(uint8_t channelsDac[4], double vi[4], double vf[4], do
 }
 
 
-uint8_t RAMPS::bufferRamp(uint8_t channelsDac[4], double vi[4], double vf[4], uint32_t nSteps, uint32_t del, uint8_t channelsAdc[16]) {
-  
-  //Serial.println("| simpleRamp : ");
-
-  //double prevVoltage;
-
-  calcDv(channelsDac, vi, vf, nSteps);
-
-  // Serial.print("dv : ");
-  //   for (int i = 0; i < 4; i++) {
-  //      Serial.print(dv[i], 6);
-  //      Serial.print(", ");
-  //   } 
+uint8_t RAMPS::bufferRamp(uint8_t channelsDac[4], double vi[4], double vf[4], uint32_t nPoints, uint32_t del, uint8_t channelsAdc[16]) {
+  if (nPoints==0) {
+    return 1;
+  }
+  calcDv(channelsDac, vi, vf, nPoints);
 
   setVi(channelsDac, vi);
-  // Serial.println("");
 
-  // Serial.print("Initial voltages: ");
-  //   for (int i = 0; i < 4; i++) {
-  //      Serial.print(dac.readVoltage(i));
-  //      Serial.print(", ");
-  //   } 
-
-  bufferRampIteration(channelsDac, vi, nSteps, del, channelsAdc);
-
-  //Serial.println("");
-
+  bufferRampIteration(channelsDac, vi, nPoints, del, channelsAdc);
 }

--- a/src/ramp.cpp
+++ b/src/ramp.cpp
@@ -131,7 +131,7 @@ uint8_t RAMPS::simpleRampIteration(uint8_t channelsDac[4], double vi[4], double 
  * @param del The delay in milliseconds between each step of the ramp.
  * @return void
  */
-uint8_t RAMPS::bufferRampIteration(uint8_t channelsDac[4], double vi[4], double nSteps, double del) {
+uint8_t RAMPS::bufferRampIteration(uint8_t channelsDac[4], double vi[4], uint32_t nSteps, uint32_t del, uint8_t channelsAdc[16]) {
 
   double dv_j;
 
@@ -139,8 +139,7 @@ uint8_t RAMPS::bufferRampIteration(uint8_t channelsDac[4], double vi[4], double 
   delay(del);
 
   //Initial reading before first step
-  adc.bufferRampFullReading();
-
+  adc.bufferRampFullReading(channelsAdc);
 
   for (int i = 0; i < nSteps; i++) {
     for (int j = 0; j < 4; j++) {
@@ -160,7 +159,7 @@ uint8_t RAMPS::bufferRampIteration(uint8_t channelsDac[4], double vi[4], double 
     delay(del);
 
     //Read
-    adc.bufferRampFullReading();
+    adc.bufferRampFullReading(channelsAdc);
   }
   return 0;
 }
@@ -186,7 +185,7 @@ uint8_t RAMPS::bufferRampIteration(uint8_t channelsDac[4], double vi[4], double 
  * @param buffer Indicates whether to use buffer ramp iteration (true) or simple ramp iteration (false).
  * @return void
  */
-uint8_t RAMPS::simpleRamp(uint8_t channelsDac[4], double vi[4], double vf[4], double nSteps, double del, bool buffer) {
+uint8_t RAMPS::simpleRamp(uint8_t channelsDac[4], double vi[4], double vf[4], double nSteps, double del) {
   
   //Serial.println("| simpleRamp : ");
 
@@ -209,10 +208,39 @@ uint8_t RAMPS::simpleRamp(uint8_t channelsDac[4], double vi[4], double vf[4], do
   //      Serial.print(", ");
   //   } 
 
-  if (buffer) {bufferRampIteration(channelsDac, vi, nSteps, del);}
-  else {simpleRampIteration(channelsDac, vi, nSteps, del);}
+  simpleRampIteration(channelsDac, vi, nSteps, del);
 
   
+  //Serial.println("");
+
+}
+
+
+uint8_t RAMPS::bufferRamp(uint8_t channelsDac[4], double vi[4], double vf[4], uint32_t nSteps, uint32_t del, uint8_t channelsAdc[16]) {
+  
+  //Serial.println("| simpleRamp : ");
+
+  //double prevVoltage;
+
+  calcDv(channelsDac, vi, vf, nSteps);
+
+  // Serial.print("dv : ");
+  //   for (int i = 0; i < 4; i++) {
+  //      Serial.print(dv[i], 6);
+  //      Serial.print(", ");
+  //   } 
+
+  setVi(channelsDac, vi);
+  // Serial.println("");
+
+  // Serial.print("Initial voltages: ");
+  //   for (int i = 0; i < 4; i++) {
+  //      Serial.print(dac.readVoltage(i));
+  //      Serial.print(", ");
+  //   } 
+
+  bufferRampIteration(channelsDac, vi, nSteps, del, channelsAdc);
+
   //Serial.println("");
 
 }


### PR DESCRIPTION
## Implementation of BufferRamp

BufferRamp is a mode to automate and speed up measurements. In this mode, the DAC-ADC ramps the specified DAC channels for a specified number of points. After each DAC channel has been updated, the system waits for an specified delay (miliseconds for now) and then measures the specified ADC channels. The ADC measurements are written to the serial buffer in raw bytes format and not in ASCII code.